### PR TITLE
Return success from pinctrl_bind_pins()

### DIFF
--- a/target/linux/ramips/patches-4.14/9999-fix-pwm-probe.patch
+++ b/target/linux/ramips/patches-4.14/9999-fix-pwm-probe.patch
@@ -1,0 +1,20 @@
+--- a/drivers/base/pinctrl.c	2018-12-09 16:17:51.760614970 +0530
++++ b/drivers/base/pinctrl.c	2018-12-09 16:19:18.076611360 +0530
+@@ -94,13 +94,9 @@
+ 	devm_kfree(dev, dev->pins);
+ 	dev->pins = NULL;
+ 
+-	/* Return deferrals */
+-	if (ret == -EPROBE_DEFER)
+-		return ret;
+-	/* Return serious errors */
+-	if (ret == -EINVAL)
+-		return ret;
+-	/* We ignore errors like -ENOENT meaning no pinctrl state */
++	/* Only return deferrals */
++	if (ret != -EPROBE_DEFER)
++		ret = 0;
+ 
+-	return 0;
++	return ret;
+ }


### PR DESCRIPTION
Return success from pinctrl_bind_pins(), in case of pin request which is already claimed by somebody else

issue started since linux kernel upsteam commit
eb4ec68acf5ebb312d29840287e465d3d414b07e

Signed-off-by: Jaymin Patel <jem.patel@gmail.com>