### PR TITLE
Fix docker image build issues related to node-gyp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:disco
 MAINTAINER Lazar Demin (lazar@onion.io)
 
 RUN apt-get update && apt-get install -y \
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     vim \
     git \
     wget \
+    rsync \
     curl \
     time \
     subversion \
@@ -24,7 +25,7 @@ RUN apt-get update && apt-get install -y \
     default-jdk \
     npm
 
-RUN npm install -g n node-gyp && n 4.3.1 && dpkg -r --force-depends nodejs
+RUN npm install -g node-gyp
 
 ENV FORCE_UNSAFE_CONFIGURE 1
 


### PR DESCRIPTION
Tried a number of fixes to resolve with ubuntu 18.04 without success.

Update to Ubuntu 19.04 (disco).

Install rsync as it is a dependency of npm.

Remove override of nodejs version, it isn't necessary anymore.

Note that npm reports that node v10 isn't compatible but this is a known issue being fixed in ubuntu

Docker image builds successfully now and confirmed that the openwrt build completes successfully as well.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
