### PR TITLE
onion: fix Onion version info was commited for the wrong file

### DIFF
--- a/files/etc/uci-defaults/12_onion_version
+++ b/files/etc/uci-defaults/12_onion_version
@@ -3,8 +3,7 @@
 uci -q batch <<-EOF > /dev/null
 	set onion.@onion[0].version='0.3.2'
 	set onion.@onion[0].build='240'
-	commit system
+	commit onion
 EOF
 
 exit 0
-


### PR DESCRIPTION
The 'commit' for the Onion version info didn't match the file where the changes were made.
By chance it works, most likely because another script issues a commit for all sections.