### PR TITLE
WIP: allow building with gcc 10+

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -28,8 +28,8 @@ $(eval $(call TestHostCommand,proper-umask, \
 
 $(eval $(call SetupHostCommand,gcc, \
 	Please install the GNU C Compiler (gcc) 4.8 or later \
-	$(CC) -dumpversion | grep -E '^(4\.[8-9]|[5-9]\.?)', \
-	gcc -dumpversion | grep -E '^(4\.[8-9]|[5-9]\.?)', \
+	$(CC) -dumpversion | grep -E '^(4\.[8-9]|[5-9]|10\.?)', \
+	gcc -dumpversion | grep -E '^(4\.[8-9]|[5-9]|10\.?)', \
 	gcc48 --version | grep gcc, \
 	gcc49 --version | grep gcc, \
 	gcc5 --version | grep gcc, \
@@ -47,8 +47,8 @@ $(eval $(call TestHostCommand,working-gcc, \
 
 $(eval $(call SetupHostCommand,g++, \
 	Please install the GNU C++ Compiler (g++) 4.8 or later \
-	$(CXX) -dumpversion | grep -E '^(4\.[8-9]|[5-9]\.?)', \
-	g++ -dumpversion | grep -E '^(4\.[8-9]|[5-9]\.?)', \
+	$(CXX) -dumpversion | grep -E '^(4\.[8-9]|[5-9]|10\.?)', \
+	g++ -dumpversion | grep -E '^(4\.[8-9]|[5-9]|10\.?)', \
 	g++48 --version | grep g++, \
 	g++49 --version | grep g++, \
 	g++5 --version | grep g++, \


### PR DESCRIPTION
Hey,

when building with Fedora/Arch/Manjaro, the `prereq-build.mk` script misdetects `gcc 10.X.X` as too old (due to [5-9] range in the regex). I patched the regexes checking the compiler version so that it is possible to build with `gcc 10+` without overriding all the prerequisites checks.

EDIT: Turns out that a patch from [here](https://forum.openwrt.org/t/compile-error-19-07/44423) needs to be applied to fix some redefinition errors. I'm trying to get it to work with both gcc10 and gcc8