### PR TITLE
tools: mkimage: fix __u64 typedef conflict with new glibc

### DIFF
--- a/tools/mkimage/patches/060-remove_kernel_includes.patch
+++ b/tools/mkimage/patches/060-remove_kernel_includes.patch
@@ -1,10 +1,9 @@
 --- a/include/compiler.h
 +++ b/include/compiler.h
-@@ -66,6 +66,11 @@ typedef uint8_t __u8;
+@@ -66,6 +66,10 @@ typedef uint8_t __u8;
  typedef uint16_t __u16;
  typedef uint32_t __u32;
  typedef unsigned int uint;
-+typedef uint64_t __u64;
 +#ifndef linux
 +typedef int __kernel_daddr_t;
 +typedef unsigned int __kernel_ino_t;


### PR DESCRIPTION
This cherry-picks in [this commit](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=f54bc3985a2fbc30256d9aee8ea3b60b8aee593a#patch1) which fixes building with newer glibc. Please see original description below:

Including "sys/stat.h" from newer glibc will cause __u64 from linux uapi header to be included, causing compilation failure for u-boot tools USE_HOSTCC

Remove typedef for __u64 in include/compiler.h to fix the issue.  It should be safe because as of u-boot-2018.03, no ref to __u64 is found under u-boot tools/ directory

Error message snippet follows

	  HOSTCC  tools/mkenvimage.o
	In file included from /usr/include/asm-generic/types.h:7,
			 from /usr/include/asm/types.h:5,
			 from /usr/include/linux/types.h:5,
			 from /usr/include/linux/stat.h:5,
			 from /usr/include/bits/statx.h:30,
			 from /usr/include/sys/stat.h:446,
			 from tools/mkenvimage.c:21:
	/usr/include/asm-generic/int-ll64.h:31:42: error: conflicting types for '__u64'
	   31 | __extension__ typedef unsigned long long __u64;
	      |                                          ^~~~~
	In file included from <command-line>:
	././include/compiler.h:69:18: note: previous declaration of '__u64' was here
	   69 | typedef uint64_t __u64;
	      |                  ^~~~~
	make[5]: *** [scripts/Makefile.host:116: tools/mkenvimage.o] Error 1

Ref: https://forum.openwrt.org/t/compile-error-19-07/44423
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1699194
Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>