### PR TITLE
gcc and g++ check fails , so adding this line fixed it for me

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -37,6 +37,7 @@ $(eval $(call SetupHostCommand,gcc, \
 	gcc7 --version | grep gcc, \
 	gcc8 --version | grep gcc, \
 	gcc9 --version | grep gcc, \
+	gcc --version | grep gcc, \
 	gcc --version | grep Apple.LLVM ))
 
 $(eval $(call TestHostCommand,working-gcc, \
@@ -56,6 +57,7 @@ $(eval $(call SetupHostCommand,g++, \
 	g++7 --version | grep g++, \
 	g++8 --version | grep g++, \
 	g++9 --version | grep g++, \
+	g++ --version | grep g++, \
 	g++ --version | grep Apple.LLVM ))
 
 $(eval $(call TestHostCommand,working-g++, \


### PR DESCRIPTION
My gcc and g++ check fails when I run make menu config, so it wasn't grepping for gcc so I added this line
