### PR TITLE
ramips: fix omega2pro device image size definition

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -108,7 +108,7 @@ TARGET_DEVICES += omega2p
 
 define Device/omega2pro
   DTS := OMEGA2PRO
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
   DEVICE_TITLE := Onion Omega2 Pro
   DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools kmod-sdhci-mt7620
 endef


### PR DESCRIPTION
Omega2Pro image size changes from 16MB to 32MB based on its flash memory.
Build system checks image size at the end of the build pocess. If the
image is bigger than the the maximum size value for the corresponding
device the following warning message is displayed if `V=s` option used
when executing make command.
`WARNING: Image file {file-name} is too big`
In addition, the generated binary is removed.